### PR TITLE
Introduced protections against predictable RNG abuse

### DIFF
--- a/models-sim/policy-models-sim-pdp/src/main/java/org/onap/policy/models/sim/pdp/PdpSimulatorActivator.java
+++ b/models-sim/policy-models-sim-pdp/src/main/java/org/onap/policy/models/sim/pdp/PdpSimulatorActivator.java
@@ -21,6 +21,7 @@
 
 package org.onap.policy.models.sim.pdp;
 
+import java.security.SecureRandom;
 import java.util.List;
 import java.util.Random;
 import lombok.Getter;
@@ -60,7 +61,7 @@ public class PdpSimulatorActivator {
      * This simulator is only used for testing. Consequently, it is safe to use a simple
      * random number generator, thus the sonar is disabled.
      */
-    private static final Random RANDOM = new Random();      // NOSONAR
+    private static final Random RANDOM = new SecureRandom();      // NOSONAR
 
     /**
      * Listens for messages on the topic, decodes them into a message, and then dispatches them.


### PR DESCRIPTION
This change replaces all new instances of `java.util.Random` with the marginally slower, but much more secure `java.security.SecureRandom`.

We have to work pretty hard to get computers to generate genuinely unguessable random bits. The `java.util.Random` type uses a method of pseudo-random number generation that unfortunately emits fairly predictable numbers.

If the numbers it emits are predictable, then it's obviously not safe to use in cryptographic operations, file name creation, token construction, password generation, and anything else that's related to security. In fact, it may affect security even if it's not directly obvious.

Switching to a more secure version is simple and our changes all look something like this:

```diff
- Random r = new Random();
+ Random r = new java.security.SecureRandom();
```

<details>
  <summary>More reading</summary>

  * [https://owasp.org/www-community/vulnerabilities/Insecure_Randomness](https://owasp.org/www-community/vulnerabilities/Insecure_Randomness)
  * [https://metebalci.com/blog/everything-about-javas-securerandom/](https://metebalci.com/blog/everything-about-javas-securerandom/)
  * [https://cwe.mitre.org/data/definitions/330.html](https://cwe.mitre.org/data/definitions/330.html)
</details>

🧚🤖  Powered by Pixeebot  

[Feedback](https://ask.pixee.ai/feedback) | [Community](https://pixee-community.slack.com/signup#/domain-signup) | [Docs](https://docs.pixee.ai/) | Codemod ID: [pixee:java/secure-random](https://docs.pixee.ai/codemods/java/pixee_java_secure-random) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Java%2FONAP_policy-models%7Cc2a9e74ecff3744b65401d1e2d0b3e3661a3371a)


<!--{"type":"DRIP","codemod":"pixee:java/secure-random"}-->